### PR TITLE
toString doesn't always work on typed arrays

### DIFF
--- a/src/zvm/text.js
+++ b/src/zvm/text.js
@@ -332,7 +332,7 @@ module.exports = {
 		addr += 2;
 		while ( addr < endaddr )
 		{
-			dict['' + memory.getBuffer8( addr, 6 )] = addr;
+			dict[Array.prototype.toString.call(memory.getBuffer8( addr, 6 ))] = addr;
 			addr += entry_len;
 		}
 		this.dictionaries[addr_start] = dict;


### PR DESCRIPTION
According to the spec, TypedArray does not define its own toString and inherits it directly from Object. In implementations that follow this (like SpiderMonkey), this causes the dictionary to be effectively empty. In v8, TypedArray's toString is somehow Array.prototype.toString. This fix just manually uses that toString.