### PR TITLE
Support the new, nicer style for getting your fileref_create_by_prompt result back

### DIFF
--- a/src/zvm.js
+++ b/src/zvm.js
@@ -85,10 +85,12 @@ api = {
 			if ( !this.quit )
 			{
 				this.glk_event = new Glk.RefStruct();
-				if (!this.glk_block_call) {
+				if ( !this.glk_block_call )
+				{
 					Glk.glk_select( this.glk_event );
 				}
-				else {
+				else
+				{
 					this.glk_event.push_field(this.glk_block_call);
 				}
 				Glk.update();
@@ -149,10 +151,12 @@ api = {
 			if ( !this.quit )
 			{
 				this.glk_event = new Glk.RefStruct();
-				if (!this.glk_block_call) {
+				if ( !this.glk_block_call )
+				{
 					Glk.glk_select( this.glk_event );
 				}
-				else {
+				else
+				{
 					this.glk_event.push_field(this.glk_block_call);
 				}
 				Glk.update();

--- a/src/zvm.js
+++ b/src/zvm.js
@@ -80,11 +80,17 @@ api = {
 			
 			// Initiate the engine, run, and wait for our first Glk event
 			this.restart();
+			this.glk_block_call = null;
 			this.run();
 			if ( !this.quit )
 			{
 				this.glk_event = new Glk.RefStruct();
-				Glk.glk_select( this.glk_event );
+				if (!this.glk_block_call) {
+					Glk.glk_select( this.glk_event );
+				}
+				else {
+					this.glk_event.push_field(this.glk_block_call);
+				}
 				Glk.update();
 			}
 		}
@@ -99,7 +105,7 @@ api = {
 		}
 	},
 
-	resume: function()
+	resume: function(resumearg)
 	{
 		var Glk = this.Glk,
 		glk_event = this.glk_event,
@@ -127,12 +133,13 @@ api = {
 				this.update_width();
 			}
 			// glk_fileref_create_by_prompt handler
-			if ( event_type === -1 )
+			if ( event_type === 'fileref_create_by_prompt' )
 			{
-				this.handle_create_fileref( glk_event.get_field( 1 ) );
+				this.handle_create_fileref( resumearg );
 				run = 1;
 			}
 			
+			this.glk_block_call = null;
 			if ( run )
 			{
 				this.run();
@@ -142,7 +149,12 @@ api = {
 			if ( !this.quit )
 			{
 				this.glk_event = new Glk.RefStruct();
-				Glk.glk_select( this.glk_event );
+				if (!this.glk_block_call) {
+					Glk.glk_select( this.glk_event );
+				}
+				else {
+					this.glk_event.push_field(this.glk_block_call);
+				}
 				Glk.update();
 			}
 		}

--- a/src/zvm/io.js
+++ b/src/zvm/io.js
@@ -146,6 +146,7 @@ module.exports = {
 	fileref_create_by_prompt: function( data )
 	{
 		this.fileref_data = data;
+		this.glk_block_call = 'fileref_create_by_prompt';
 		this.Glk.glk_fileref_create_by_prompt( data.usage, data.mode, data.rock || 0 );
 	},
 


### PR DESCRIPTION
Okay, this should get us synced up on how to handle fileref_create_by_prompt. (Along with my latest glkote/quixe changes).

I did the obvious thing: when VM.resume is called after fileref_create_by_prompt, it receives an argument which is the fileref. (When VM.resume is called after glk_select, it receives no argument.)

With this change, ZVM should *not* call glk_select after glk_fileref_create_by_prompt. As you see in this commit, there's a new `this.glk_block_call` field which gets set to the string "fileref_create_by_prompt" in this case. We set up `this.glk_event` with that string (and no other fields) so that VM.resume can recognize what's going on.

With this in, save/restore/transcript all seem to work in Lectrote.
