### PR TITLE
MemoryView ctor should allow for typed arrays over subset of buffer

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ Dannii Willis <curiousdannii@gmail.com>
 Andrew Plotkin <erkyrath@eblong.com>
 Matthew Wightman <matthew.wightman@gmail.com>
 Mitch Foley <mitch@thefoley.net>
+Daniel Lehenbauer <DLehenbauer@users.noreply.github.com>

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -59,7 +59,8 @@ function MemoryView( buffer, byteOffset, byteLength )
 	// Typed arrays
 	if ( buffer.buffer )
 	{
-		buffer = buffer.buffer;
+		// Note that typed array may not span the entire undelying buffer.
+		buffer = buffer.buffer.slice( /* start */ buffer.byteOffset, /* end */ ( buffer.byteOffset + buffer.byteLength ) );
 	}
 	
 	return extend( new DataView( buffer, byteOffset, byteLength ), {

--- a/src/zvm.js
+++ b/src/zvm.js
@@ -79,7 +79,7 @@ api = {
 			
 			// Make a seperate MemoryView for the ram, and store the original ram
 			this.staticmem = this.m.getUint16( 0x0E );
-			this.ram = utils.MemoryView( this.m.buffer, 0, this.staticmem );
+			this.ram = utils.MemoryView( this.m.buffer, this.m.byteOffset, this.staticmem );
 			this.origram = this.m.getUint8Array( 0, this.staticmem );
 
 			// Cache the game signature

--- a/src/zvm.js
+++ b/src/zvm.js
@@ -79,7 +79,7 @@ api = {
 			
 			// Make a seperate MemoryView for the ram, and store the original ram
 			this.staticmem = this.m.getUint16( 0x0E );
-			this.ram = utils.MemoryView( this.m.buffer, this.m.byteOffset, this.staticmem );
+			this.ram = utils.MemoryView( this.m, 0, this.staticmem );
 			this.origram = this.m.getUint8Array( 0, this.staticmem );
 
 			// Cache the game signature


### PR DESCRIPTION
Simple fix for Issue #58.

On Windows w/node v9.2.0, file.identify() would fail immediately because the expected FourCC/zcode version was not at offset 0 in the underlying buffer.

Short .z3 files now load w/the change.